### PR TITLE
Add "Unstable" status to Jenkins job results

### DIFF
--- a/python/blinky/jenkins.py
+++ b/python/blinky/jenkins.py
@@ -26,7 +26,7 @@ _log = _logging.getLogger("blinky.jenkins")
 _status_mapping = {
     "SUCCESS": PASSED,
     "FAILURE": FAILED,
-    "UNSTABLE": FAILED,
+    "UNSTABLE": UNSTABLE,
 }
 
 class JenkinsAgent(HttpAgent):

--- a/python/blinky/model.py
+++ b/python/blinky/model.py
@@ -32,6 +32,7 @@ _log = _logging.getLogger("blinky.model")
 
 PASSED = "PASSED"
 FAILED = "FAILED"
+UNSTABLE = "UNSTABLE"
 
 class Model:
     def __init__(self):

--- a/static/app.css
+++ b/static/app.css
@@ -150,6 +150,10 @@ div.job.failed a.job-summary {
     background-color: rgb(255, 63, 0);
 }
 
+div.job.unstable a.job-summary {
+    background-color: rgb(255, 189, 0);
+}
+
 div.job.no-data a.job-summary, div.job.stale-data a.job-summary {
     border: 0.2em solid rgb(191, 191, 191);
     background-color: white;

--- a/static/app.js
+++ b/static/app.js
@@ -248,8 +248,13 @@ class Blinky {
 
         if (currResult.status === "PASSED") {
             elem.classList.add("passed");
-        } else if (currResult.status === "FAILED") {
-            elem.classList.add("failed");
+        } else {
+            if (currResult.status === "FAILED") {
+                elem.classList.add("failed");
+            }
+            if (currResult.status === "UNSTABLE") {
+                elem.classList.add("unstable");
+            }
 
             if (prevResult != null && prevResult.status === "PASSED") {
                 elem.classList.add("blinky");


### PR DESCRIPTION
Added a new status, "Unstable", to represent test runs that have not failed but also have not passed completely. This change modifies the model to include the "Unstable" status and updates the JenkinsAgent and the frontend to handle and display this new status accordingly. An unstable job will now be represented with a different color (rgb(255, 189, 0)). This change helps to enhance the clarity of test results' interpretation.

![image](https://github.com/ssorj/blinky/assets/442720/7926352a-46db-4e9c-9dde-49a08935d03b)