### PR TITLE
Fix for handling 'None' in JSON actions list from Apache Jenkins instance

### DIFF
--- a/python/blinky/jenkins.py
+++ b/python/blinky/jenkins.py
@@ -57,9 +57,10 @@ class JenkinsJob(HttpJob):
         tests_url = None
 
         for action in data["actions"]:
-            if action.get("_class") == "hudson.tasks.junit.TestResultAction":
-                tests_url = f"{html_url}/testReport"
-                break
+            if action is not None:
+                if action.get("_class") == "hudson.tasks.junit.TestResultAction":
+                    tests_url = f"{html_url}/testReport"
+                    break
 
         result = JobResult()
         result.number = number


### PR DESCRIPTION
Some upstream client jobs in RH blinky appear white with the following error message:
```
Traceback (most recent call last):
  File "/app/lib/blinky/python/blinky/model.py", line 274, in update
    result = self.convert_result(data)
             ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/lib/blinky/python/blinky/jenkins.py", line 61, in convert_result
    if action.get("_class") == "hudson.tasks.junit.TestResultAction":
       ^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'get'
```

Debugging shows that some jobs return a JSON actions list that contain a JSON None type. This trivial fix tests for that possibility and allows the call to complete successfully when this occurs.

Tested locally, works.

If this is merged, built and pushed to quay.io, then the RH instance can be updated.